### PR TITLE
Fix builds in chroot environment

### DIFF
--- a/darwinbuild/darwinbuild.in
+++ b/darwinbuild/darwinbuild.in
@@ -756,32 +756,27 @@ cat <<-EOF > $SCRIPT
 EOF
 if [ "$logdeps" == "YES" ]; then
 	if [ "$USE_CHROOT" == "YES" ]; then
-		if [ "$DARWINTRACE" -nt "$BuildRoot/usr/lib/darwintrace.dylib" ]; then
-			mkdir -p "$BuildRoot/usr/lib"
-			cp "$DARWINTRACE" \
-		   	"$BuildRoot/usr/lib/darwintrace.dylib"
-		fi
+		mkdir -p "$BuildRoot/usr/lib"
+		cp "$DARWINTRACE" \
+		"$BuildRoot/usr/lib/darwintrace.dylib"
+
 		echo "export DARWINTRACE_LOG=\"${TRACELOG/$BuildRoot/}\"" >> $SCRIPT
 		echo "export DYLD_INSERT_LIBRARIES=/usr/lib/darwintrace.dylib" >> $SCRIPT
 	else
 		echo "export DARWINTRACE_LOG=\"${TRACELOG}\"" >> $SCRIPT
 		echo "export DYLD_INSERT_LIBRARIES=$DARWINTRACE" >> $SCRIPT
 	fi
-
-	echo "export DYLD_FORCE_FLAT_NAMESPACE=1" >> $SCRIPT
 fi
 
-if [ "$INSTALL_XCODE" == "YES" ]; then
+if [ "$INSTALL_XCODE" == "YES" -a "$USE_CHROOT" == "NO" ]; then
 	echo "*** Redirecting ..."
 	echo "DARWINTRACE_REDIRECT=\"${BuildRoot}\""
 	echo "DARWINTRACE_LOG=\"${TRACELOG}\""
 	echo "DYLD_INSERT_LIBRARIES=$DARWINTRACE"
-	echo "DYLD_FORCE_FLAT_NAMESPACE=1"
 	echo ""
 	echo "export DARWINTRACE_REDIRECT=\"${BuildRoot}\"" >> $SCRIPT
 	echo "export DARWINTRACE_LOG=\"${TRACELOG}\"" >> $SCRIPT
 	echo "export DYLD_INSERT_LIBRARIES=$DARWINTRACE" >> $SCRIPT
-	echo "export DYLD_FORCE_FLAT_NAMESPACE=1" >> $SCRIPT
 fi
 
 if [ "$buildtool" == "xcodebuild" ]; then

--- a/darwinbuild/darwinbuild.in
+++ b/darwinbuild/darwinbuild.in
@@ -592,19 +592,13 @@ fi
 numfiles=$(echo *.pbxproj *.pbproj *.xcode *.xcodeproj 2> /dev/null )
 if [ -n "$numfiles" ]; then
     	buildtool="xcodebuild"
-	# we use a platform/sdk instead of chrooting for Xcode projects
-	# but allow -nochroot to disable Xcode integration
-	if [ $USE_CHROOT == "YES" ]; then
-	    export USE_CHROOT="NO"
-	    export INSTALL_XCODE="YES"
-	fi
+    	export INSTALL_XCODE="YES"
 else
 	buildtool="make"
 
 	# test for hybrid make-xcode project
 	uses_xcrun=$(grep -Elir 'xcodebuild|xcrun|Commands.make|BSDCommon.make|Standard.make|Common.make' .)
 	if [ -n "$uses_xcrun" -a $USE_CHROOT == "YES" ]; then
-		export USE_CHROOT="NO"
 		export INSTALL_XCODE="YES"
 	fi
 fi

--- a/darwinbuild/installXcode_Modern
+++ b/darwinbuild/installXcode_Modern
@@ -56,3 +56,8 @@ ditto /Applications/Xcode.app/Contents/version.plist $BUILDROOT/Applications/Xco
 
 mkdir -p $BUILDROOT/System/Library/CoreServices
 ditto /System/Library/CoreServices/SystemVersion.plist $BUILDROOT/System/Library/CoreServices
+
+# Create extra directories required by the Xcode tools.
+# While not strictly part of Xcode, without them the tools will crash.
+mkdir -p $BUILDROOT/Users/$(whoami)
+mkdir -p $BUILDROOT/$TMPDIR

--- a/darwinbuild/installXcode_Modern
+++ b/darwinbuild/installXcode_Modern
@@ -52,3 +52,6 @@ do_ditto /Applications/Xcode.app/Contents/Developer/usr
 
 do_ditto /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform
 ditto /Applications/Xcode.app/Contents/Info.plist $BUILDROOT/Applications/Xcode.app/Contents
+
+mkdir -p $BUILDROOT/System/Library/CoreServices
+ditto /System/Library/CoreServices/SystemVersion.plist $BUILDROOT/System/Library/CoreServices

--- a/darwinbuild/installXcode_Modern
+++ b/darwinbuild/installXcode_Modern
@@ -52,6 +52,7 @@ do_ditto /Applications/Xcode.app/Contents/Developer/usr
 
 do_ditto /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform
 ditto /Applications/Xcode.app/Contents/Info.plist $BUILDROOT/Applications/Xcode.app/Contents
+ditto /Applications/Xcode.app/Contents/version.plist $BUILDROOT/Applications/Xcode.app/Contents
 
 mkdir -p $BUILDROOT/System/Library/CoreServices
 ditto /System/Library/CoreServices/SystemVersion.plist $BUILDROOT/System/Library/CoreServices

--- a/darwinbuild/installXcode_Modern
+++ b/darwinbuild/installXcode_Modern
@@ -51,3 +51,4 @@ do_ditto /Applications/Xcode.app/Contents/Developer/Tools
 do_ditto /Applications/Xcode.app/Contents/Developer/usr
 
 do_ditto /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform
+ditto /Applications/Xcode.app/Contents/Info.plist /Applications/Xcode.app/Contents

--- a/darwinbuild/installXcode_Modern
+++ b/darwinbuild/installXcode_Modern
@@ -51,4 +51,4 @@ do_ditto /Applications/Xcode.app/Contents/Developer/Tools
 do_ditto /Applications/Xcode.app/Contents/Developer/usr
 
 do_ditto /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform
-ditto /Applications/Xcode.app/Contents/Info.plist /Applications/Xcode.app/Contents
+ditto /Applications/Xcode.app/Contents/Info.plist $BUILDROOT/Applications/Xcode.app/Contents


### PR DESCRIPTION
This PR resolves the remaining issues in my chroot implementation (introduced in #1), such that it can now build a Makefile-based or Xcodeproj-based project inside the chroot with no errors. I debugged this by manually entering the chroot environment and running Make by hand.