### PR TITLE
Adjust behavior of patch command

### DIFF
--- a/darwinbuild/darwinbuild.in
+++ b/darwinbuild/darwinbuild.in
@@ -564,10 +564,10 @@ for patchfile in $patchfilenames; do
 	    esac
 	    case $patchfile in
 		*.p1.patch*)
-		    $catprog "$SourceCache/$patchfile" | patch -p1 -r .
+		    $catprog "$SourceCache/$patchfile" | patch -p1 -N -r /dev/null
 		    ;;
 		*.patch*)
-		    $catprog "$SourceCache/$patchfile" | patch -p0 -r .
+		    $catprog "$SourceCache/$patchfile" | patch -p0 -N -r /dev/null
 		    ;;
 		*.add*)
 		    newfile=`echo $patchfile | sed -e 's/^.*-\([^-]*\)\.add.*/\1/' -e 's,_,/,g'`


### PR DESCRIPTION
Now, `*.rej` files will be discarded (saved to `/dev/null`) instead of accumulating in the build root. In addition, previously, if a patch created a new file that is already present, the patch program would pause for interactive input. Now, the program simply ignores such patches.