### PR TITLE
Fix build issue involving writing the platform version file

### DIFF
--- a/darwinbuild/darwinbuild.in
+++ b/darwinbuild/darwinbuild.in
@@ -612,7 +612,7 @@ mkdir -p "$receipts"
 if [ $INSTALL_XCODE == "YES" ]; then
 	if [ ! -f "$receipts/xcodebuild" ]; then
 		echo "*** Installing Xcode Tools ..."
-		"$DATADIR/installXcode" "$BuildRoot"
+		"$DATADIR/installXcode" "$BuildRoot" "$PWDP"
 		touch "$receipts/xcodebuild"
 	fi
 fi

--- a/darwinbuild/installXcode.in
+++ b/darwinbuild/installXcode.in
@@ -8,7 +8,7 @@ VER=$(/usr/bin/xcodebuild -version | grep version | cut -d "-" -f 2 | cut -d ";"
 
 if [ -e /Applications/Xcode.app ]; then
 	"$BINDIR/installXcode_Modern" "$BROOT"
-	echo macosx10.12 > .build/platform
+	echo macosx10.12 > $2/.build/platform
 	exit 0
 fi
 


### PR DESCRIPTION
Previously, the `installXcode` script assumed it was run in the `darwinbuild` working directory. Since empirical testing has proved that this is not the case, I must specify an absolute path instead.