### PR TITLE
Fix a problem concerning symbolic links

### DIFF
--- a/darwinbuild/installXcode_Modern
+++ b/darwinbuild/installXcode_Modern
@@ -63,3 +63,7 @@ mkdir -p $BUILDROOT/Users/$(whoami)
 mkdir -p $BUILDROOT/$(getconf DARWIN_USER_DIR)
 mkdir -p $BUILDOROT/$(getconf DARWIN_USER_TEMP_DIR)
 mkdir -p $BUILDROOT/$(getconf DARWIN_USER_CACHE_DIR)
+
+# Now I must remove a symbolic link, or darwinbuild will fail later.
+rm $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
+mv $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk


### PR DESCRIPTION
`darwinbuild` invokes `ditto`, which does not traverse symbolic links when installing files. (It simply prints an error and exits instead.) I must therefore remove the symbolic link, and then move its target over it so nothing appears to have changed.