### PR TITLE
Add support for High Sierra

### DIFF
--- a/darwinbuild/darwinbuild.in
+++ b/darwinbuild/darwinbuild.in
@@ -595,12 +595,6 @@ if [ -n "$numfiles" ]; then
     	export INSTALL_XCODE="YES"
 else
 	buildtool="make"
-
-	# test for hybrid make-xcode project
-	uses_xcrun=$(grep -Elir 'xcodebuild|xcrun|Commands.make|BSDCommon.make|Standard.make|Common.make' .)
-	if [ -n "$uses_xcrun" -a $USE_CHROOT == "YES" ]; then
-		export INSTALL_XCODE="YES"
-	fi
 fi
 
 
@@ -646,14 +640,10 @@ if [ "$NEED_ROOTS" == "YES" -a "$noload" != "YES" ]; then
 
 fi
 
-### xcodebuild is a special case because it is not open source
-### we try to integrate the host copy of Xcode if required
-if [ $INSTALL_XCODE == "YES" ]; then
-	if [ ! -f "$receipts/xcodebuild" ]; then
-		echo "*** Installing Xcode Tools ..."
-		"$DATADIR/installXcode" "$BuildRoot" "$PWDP"
-		touch "$receipts/xcodebuild"
-	fi
+if [ ! -f "$receipts/xcodebuild" ]; then
+	echo "*** Installing Xcode Tools ..."
+	"$DATADIR/installXcode" "$BuildRoot" "$PWDP"
+	touch "$receipts/xcodebuild"
 fi
 
 ###

--- a/darwinbuild/darwinbuild.in
+++ b/darwinbuild/darwinbuild.in
@@ -607,16 +607,6 @@ fi
 receipts="$BuildRoot/usr/local/darwinbuild/receipts"
 mkdir -p "$receipts"
 
-### xcodebuild is a special case because it is not open source
-### we try to integrate the host copy of Xcode if required
-if [ $INSTALL_XCODE == "YES" ]; then
-	if [ ! -f "$receipts/xcodebuild" ]; then
-		echo "*** Installing Xcode Tools ..."
-		"$DATADIR/installXcode" "$BuildRoot" "$PWDP"
-		touch "$receipts/xcodebuild"
-	fi
-fi
-
 ###
 ### If we are going to build in a chroot,
 ### install the roots into the BuildRoot.
@@ -654,6 +644,16 @@ if [ "$NEED_ROOTS" == "YES" -a "$noload" != "YES" ]; then
 	    exit
 	fi
 
+fi
+
+### xcodebuild is a special case because it is not open source
+### we try to integrate the host copy of Xcode if required
+if [ $INSTALL_XCODE == "YES" ]; then
+	if [ ! -f "$receipts/xcodebuild" ]; then
+		echo "*** Installing Xcode Tools ..."
+		"$DATADIR/installXcode" "$BuildRoot" "$PWDP"
+		touch "$receipts/xcodebuild"
+	fi
 fi
 
 ###

--- a/darwinbuild/installXcode.in
+++ b/darwinbuild/installXcode.in
@@ -7,8 +7,7 @@ BROOT=$1
 VER=$(/usr/bin/xcodebuild -version | grep version | cut -d "-" -f 2 | cut -d ";" -f 1 | cut -d "." -f 1)
 
 if [ -e /Applications/Xcode.app ]; then
-	"$BINDIR/installXcode_Modern" "$BROOT"
-	echo macosx10.12 > $2/.build/platform
+	"$BINDIR/installXcode_Modern" "$BROOT" "$2"
 	exit 0
 fi
 

--- a/darwinbuild/installXcode_Modern
+++ b/darwinbuild/installXcode_Modern
@@ -65,7 +65,6 @@ mkdir -p $BUILDROOT/$(getconf DARWIN_USER_DIR)
 mkdir -p $BUILDROOT/$(getconf DARWIN_USER_TEMP_DIR)
 mkdir -p $BUILDROOT/$(getconf DARWIN_USER_CACHE_DIR)
 
-# Now I must remove a symbolic link, or darwinbuild will fail later.
 if [ "$HOST_DARWIN_VERSION" == "10.13" ]; then
     rm $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk
     mv $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk

--- a/darwinbuild/installXcode_Modern
+++ b/darwinbuild/installXcode_Modern
@@ -35,6 +35,7 @@ do_ditto () {
     ditto "$path" "$BUILDROOT/$path" || exit 1
 }
 
+HOST_DARWIN_VERSION=$(sw_vers -productVersion)
 BUILDROOT="$1"
 mkdir -p "$BUILDROOT"
 
@@ -65,5 +66,10 @@ mkdir -p $BUILDOROT/$(getconf DARWIN_USER_TEMP_DIR)
 mkdir -p $BUILDROOT/$(getconf DARWIN_USER_CACHE_DIR)
 
 # Now I must remove a symbolic link, or darwinbuild will fail later.
-rm $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
-mv $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
+if [ "$HOST_DARWIN_VERSION" == "10.13" ]; then
+    rm $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk
+    mv $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
+elif [ "$HOST_DARWIN_VERSION" == "10.12" ]; then
+    rm $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
+    mv $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
+fi

--- a/darwinbuild/installXcode_Modern
+++ b/darwinbuild/installXcode_Modern
@@ -71,6 +71,20 @@ if [ "$HOST_DARWIN_VERSION" == "10.13" ]; then
 
     mkdir -p $BUILDROOT/private/var/db
     ln -s /Applications/Xcode.app/Contents/Developer $BUILDROOT/private/var/db/xcode_select_link
+
+    # High Sierra does not allow processes with entitlements to run inside a chroot.
+    # Therefore, I must strip the entitlements and re-sign xcodebuild.
+    # Hopefully, this won't break anything.
+    cat <<EOF > $BUILDROOT/private/tmp/empty.entitlements
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>
+EOF
+
+    codesign -s - -f --entitlements $BUILDROOT/private/tmp/empty.entitlements $BUILDROOT/Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild
 elif [ "$HOST_DARWIN_VERSION" == "10.12" ]; then
     rm $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
     mv $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk

--- a/darwinbuild/installXcode_Modern
+++ b/darwinbuild/installXcode_Modern
@@ -62,7 +62,7 @@ ditto /System/Library/CoreServices/SystemVersion.plist $BUILDROOT/System/Library
 # While not strictly part of Xcode, without them the tools will crash.
 mkdir -p $BUILDROOT/Users/$(whoami)
 mkdir -p $BUILDROOT/$(getconf DARWIN_USER_DIR)
-mkdir -p $BUILDOROT/$(getconf DARWIN_USER_TEMP_DIR)
+mkdir -p $BUILDROOT/$(getconf DARWIN_USER_TEMP_DIR)
 mkdir -p $BUILDROOT/$(getconf DARWIN_USER_CACHE_DIR)
 
 # Now I must remove a symbolic link, or darwinbuild will fail later.

--- a/darwinbuild/installXcode_Modern
+++ b/darwinbuild/installXcode_Modern
@@ -69,6 +69,9 @@ mkdir -p $BUILDROOT/$(getconf DARWIN_USER_CACHE_DIR)
 if [ "$HOST_DARWIN_VERSION" == "10.13" ]; then
     rm $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk
     mv $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
+
+    mkdir -p $BUILDROOT/var/db
+    ln -s /Applications/Xcode.app/Contents/Developer $BUILDROOT/var/db/xcode_select_link
 elif [ "$HOST_DARWIN_VERSION" == "10.12" ]; then
     rm $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
     mv $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk

--- a/darwinbuild/installXcode_Modern
+++ b/darwinbuild/installXcode_Modern
@@ -67,7 +67,7 @@ mkdir -p $BUILDROOT/$(getconf DARWIN_USER_CACHE_DIR)
 
 if [ "$HOST_DARWIN_VERSION" == "10.13" ]; then
     rm $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk
-    mv $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
+    mv $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk
 
     mkdir -p $BUILDROOT/private/var/db
     ln -s /Applications/Xcode.app/Contents/Developer $BUILDROOT/private/var/db/xcode_select_link

--- a/darwinbuild/installXcode_Modern
+++ b/darwinbuild/installXcode_Modern
@@ -69,8 +69,8 @@ if [ "$HOST_DARWIN_VERSION" == "10.13" ]; then
     rm $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk
     mv $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
 
-    mkdir -p $BUILDROOT/var/db
-    ln -s /Applications/Xcode.app/Contents/Developer $BUILDROOT/var/db/xcode_select_link
+    mkdir -p $BUILDROOT/private/var/db
+    ln -s /Applications/Xcode.app/Contents/Developer $BUILDROOT/private/var/db/xcode_select_link
 elif [ "$HOST_DARWIN_VERSION" == "10.12" ]; then
     rm $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
     mv $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk

--- a/darwinbuild/installXcode_Modern
+++ b/darwinbuild/installXcode_Modern
@@ -85,7 +85,11 @@ if [ "$HOST_DARWIN_VERSION" == "10.13" ]; then
 EOF
 
     codesign -s - -f --entitlements $BUILDROOT/private/tmp/empty.entitlements $BUILDROOT/Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild
+
+    echo macosx10.13 > $2/.build/platform
 elif [ "$HOST_DARWIN_VERSION" == "10.12" ]; then
     rm $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
     mv $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
+
+    echo macosx10.12 > $2/.build/platform
 fi


### PR DESCRIPTION
As the title says, this PR aims to make it so the `installXcode_Modern` script creates a working chroot when run under the macOS High Sierra beta.

It is still a work-in-progress, though, as I still need to fix a few issues regarding the correct time to run the `createChroot` script. Once that is done, I’ll indicate when this is ready to merge. Thanks!