### PR TITLE
Add xnu copyright check patch

### DIFF
--- a/patches/xnu-3789.51.2.copyright-check.p1.patch
+++ b/patches/xnu-3789.51.2.copyright-check.p1.patch
@@ -1,0 +1,22 @@
+diff --git a/libkern/kxld/kxld_copyright.c b/libkern/kxld/kxld_copyright.c
+index e1f13c2..8664226 100644
+--- a/libkern/kxld/kxld_copyright.c
++++ b/libkern/kxld/kxld_copyright.c
+@@ -49,6 +49,7 @@
+ 
+ #define kCopyrightToken "Copyright © "
+ #define kRightsToken " Apple Inc. All rights reserved."
++#define kRightsTokenPD " PureDarwin Project. All rights reserved."
+ 
+ /******************************************************************************
+ * Globals
+@@ -252,6 +253,9 @@ kxld_validate_copyright_string(const char *str)
+ 
+     copyright = kxld_strstr(str, kCopyrightToken);
+     rights = kxld_strstr(str, kRightsToken);
++    if (!rights) {
++        rights = kxld_strstr(str, kRightsTokenPD);
++    }
+ 
+     if (!copyright || !rights || copyright > rights) goto finish;
+ 


### PR DESCRIPTION
With this patch applied, kexts no longer need to specify their copyright string as being in the name of "Apple Inc." to reference certain kernel APIs. The kernel will also accept a copyright string referencing "PureDarwin Project".

The corresponding PR for the darwinbuild plist will be forthcoming. As per usual for patches, a copyright notice was not added as the format does not support it.