### PR TITLE
Add the ability to fetch source tarballs from GitHub Releases

### DIFF
--- a/darwinbuild.xcodeproj/project.pbxproj
+++ b/darwinbuild.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		1F514C441F4A5CDA008D9341 /* fetch-from-github in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1F514C431F4A5CC0008D9341 /* fetch-from-github */; };
 		1FC854011ED462EE00EA2AF5 /* installXcode_Modern in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1FC854001ED462DF00EA2AF5 /* installXcode_Modern */; };
 		3963011A1EAB4D60006081C7 /* source_sites.c in Sources */ = {isa = PBXBuildFile; fileRef = 72C86C0E10965EEA00C66E90 /* source_sites.c */; };
 		396301211EAB4E01006081C7 /* patch_sites.c in Sources */ = {isa = PBXBuildFile; fileRef = 396301191EAB42B6006081C7 /* patch_sites.c */; };
@@ -630,6 +631,7 @@
 			dstPath = "$(DATDIR)/darwinbuild";
 			dstSubfolderSpec = 0;
 			files = (
+				1F514C441F4A5CDA008D9341 /* fetch-from-github in CopyFiles */,
 				1FC854011ED462EE00EA2AF5 /* installXcode_Modern in CopyFiles */,
 				7227AD1C109A05FA00BE33D7 /* buildlist in CopyFiles */,
 				7227AD1D109A05FA00BE33D7 /* buildorder in CopyFiles */,
@@ -660,6 +662,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1F514C431F4A5CC0008D9341 /* fetch-from-github */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; name = "fetch-from-github"; path = "darwinbuild/fetch-from-github"; sourceTree = "<group>"; };
 		1FC854001ED462DF00EA2AF5 /* installXcode_Modern */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; name = installXcode_Modern; path = darwinbuild/installXcode_Modern; sourceTree = "<group>"; };
 		396301191EAB42B6006081C7 /* patch_sites.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = patch_sites.c; sourceTree = "<group>"; };
 		396301271EAB4E01006081C7 /* patch_sites.so */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.objfile"; includeInIndex = 0; path = patch_sites.so; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1057,6 +1060,7 @@
 		72C86BD510965DC900C66E90 /* darwinbuild */ = {
 			isa = PBXGroup;
 			children = (
+				1F514C431F4A5CC0008D9341 /* fetch-from-github */,
 				720BE2E9120C909E00B3C4A5 /* digest.c */,
 				7227AB871098A7BF00BE33D7 /* buildlist */,
 				7227AB881098A7BF00BE33D7 /* buildorder */,

--- a/darwinbuild/darwinbuild.in
+++ b/darwinbuild/darwinbuild.in
@@ -462,6 +462,13 @@ if [ "$nosource" != "YES" ]; then
 		Download "$SourceCache" "$filename" "$($DARWINXREF source_sites $projnam)"
 	fi
 
+	if [ ! -f "$SourceCache/$filename" ]; then
+		github_projname=$(echo $filename | sed -e 's,-.*$,,')
+		github_projversion=$(echo $filename | sed -e 's,\.tar\.gz$,,' | sed -e 's,^.*-,,')
+		github_dxref_plist=.build/$($DARWINXREF currentBuild).plist
+		$DATADIR/fetch-from-github "$github_dxref_plist" $github_projname $github_projversion "$SourceCache"
+	fi
+
 	patchfilenames=$($DARWINXREF patchfiles $projnam)
 	for p in $patchfilenames; do
 		Download "$SourceCache" "$p" "$($DARWINXREF patch_sites $projnam)"

--- a/darwinbuild/fetch-from-github
+++ b/darwinbuild/fetch-from-github
@@ -1,4 +1,31 @@
 #!/bin/bash
+#
+# Copyright (c) 2017 William Kent. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+# 3.  Neither the name of Apple Computer, Inc. ("Apple") nor the names of
+#     its contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
 
 DARWINBUILD_PLIST=$1
 PROJECT_NAME=$2

--- a/darwinbuild/fetch-from-github
+++ b/darwinbuild/fetch-from-github
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+DARWINBUILD_PLIST=$1
+PROJECT_NAME=$2
+PROJECT_VERSION=$3
+SOURCES_DIR=$4
+
+EXTRACT_SCRIPT_FILENAME=$(mktemp /tmp/darwinbuild-fetch-from-github.XXXXXXXXXX)
+cat > $EXTRACT_SCRIPT_FILENAME <<EOF
+from __future__ import print_function
+import plistlib
+import sys
+
+filename = sys.argv[1]
+project = sys.argv[2]
+pl = plistlib.readPlist(filename)
+print(pl['projects'][project]['github'])
+EOF
+
+# Check to see if the Python script fails.
+# If it does, diagnostics will have been printed to stderr.
+python $EXTRACT_SCRIPT_FILENAME $DARWINBUILD_PLIST $PROJECT_NAME 1> /dev/null || {
+    echo Python extraction script failed 1>&2
+    rm $EXTRACT_SCRIPT_FILENAME
+    exit 1
+}
+
+GITHUB_PROJECT=$(python $EXTRACT_SCRIPT_FILENAME $DARWINBUILD_PLIST $PROJECT_NAME)
+GITHUB_URL=https://github.com/${GITHUB_PROJECT}/archive/${PROJECT_VERSION}.tar.gz
+
+echo -n "Attempting download from $GITHUB_URL "
+curl -Ls -o "${SOURCES_DIR}/${PROJECT_NAME}-${PROJECT_VERSION}.tar.gz" "${GITHUB_URL}"
+CURL_STATUS=$?
+
+rm -f $EXTRACT_SCRIPT_FILENAME
+if [ $CURL_STATUS = 0 ]; then
+    echo "- OK"
+    exit 0
+else
+    echo "- not found"
+    exit 1
+fi

--- a/darwinbuild/fetch-from-github
+++ b/darwinbuild/fetch-from-github
@@ -32,7 +32,7 @@ GITHUB_PROJECT=$(python $EXTRACT_SCRIPT_FILENAME $DARWINBUILD_PLIST $PROJECT_NAM
 
 GITHUB_URL=https://github.com/${GITHUB_PROJECT}/archive/${PROJECT_VERSION}.tar.gz
 
-echo -n "Attempting download from $GITHUB_URL "
+echo -n "Downloading $GITHUB_URL "
 curl -Ls -o "${SOURCES_DIR}/${PROJECT_NAME}-${PROJECT_VERSION}.tar.gz" "${GITHUB_URL}"
 CURL_STATUS=$?
 

--- a/darwinbuild/fetch-from-github
+++ b/darwinbuild/fetch-from-github
@@ -14,7 +14,9 @@ import sys
 filename = sys.argv[1]
 project = sys.argv[2]
 pl = plistlib.readPlist(filename)
-print(pl['projects'][project]['github'])
+
+if 'github' in pl['projects'][project]:
+    print(pl['projects'][project]['github'])
 EOF
 
 # Check to see if the Python script fails.
@@ -26,6 +28,8 @@ python $EXTRACT_SCRIPT_FILENAME $DARWINBUILD_PLIST $PROJECT_NAME 1> /dev/null ||
 }
 
 GITHUB_PROJECT=$(python $EXTRACT_SCRIPT_FILENAME $DARWINBUILD_PLIST $PROJECT_NAME)
+[ "$GITHUB_PROJECT" = "" ] && exit
+
 GITHUB_URL=https://github.com/${GITHUB_PROJECT}/archive/${PROJECT_VERSION}.tar.gz
 
 echo -n "Attempting download from $GITHUB_URL "

--- a/darwinxref/DBDataStore.c
+++ b/darwinxref/DBDataStore.c
@@ -557,8 +557,8 @@ int DBSetProp(CFStringRef build, CFStringRef project, CFStringRef property, CFTy
 	int res = 0;
 	CFTypeID type = DBCopyPropType(property);
 	if (type == -1) {
-		cfprintf(stderr, "Error: unknown property in project \"%@\": %@\n", project, property);
-		return -1;
+		// Silently ignore unknown properties.
+		return 0;
 	}
 	if (type != CFGetTypeID(value)) {
 		CFStringRef expected = CFCopyTypeIDDescription(type);


### PR DESCRIPTION
This PR does just what the title indicates. To download a source tarball from GitHub, add the `github` key to a project's entry in the darwinbuild property list, as seen here:

```xml
<key>booter</key>
<dict>
	<key>version</key>
	<string>2.0.0</string>
	<key>target</key>
	<string>boot2</string>
	<key>github</key>
	<string>Andromeda-OS/booter</string>
	<key>environment</key>
	<dict>
		<key>RC_ARCHS</key>
		<string>i386</string>
	</dict>
</dict>
```

darwinbuild will then attempt to download `https://github.com/Andromeda-OS/booter/archive/booter-2.0.0.tar.gz`.