### PR TITLE
darwinmaster fixes

### DIFF
--- a/darwinbuild/darwinbuild.common
+++ b/darwinbuild/darwinbuild.common
@@ -91,19 +91,6 @@ function GetBuildVersion() {
 	echo $maxbuild
 }
 
-###
-### Trap calls to ditto since it is only available on Mac OS X
-### Warning: only supports the directory-to-directory form
-function ditto() {
-	local srcdir="$1"
-	local dstdir="$2"
-	if [ -x /usr/bin/ditto ]; then
-		/usr/bin/ditto "$srcdir" "$dstdir"
-	else
-		tar c -C "$srcdir" . | tar xf - -C "$dstdir"
-	fi
-}
-
 CURLARGS=${CURLARGS:-}
 
 ###

--- a/darwinbuild/darwinmaster.in
+++ b/darwinbuild/darwinmaster.in
@@ -87,12 +87,17 @@ DMG="/tmp/$VOLNAME.dmg"
 CDR="/tmp/$VOLNAME.cdr"
 ISO="/tmp/$VOLNAME.iso"
 PKGDIR="$DARWIN_BUILDROOT/Packages"
-MKISOFS="/opt/local/bin/mkisofs"
 SIZE="650m"
 if [ ! -z "$ARCH" ]; then
 	ARCHSFX="_$ARCH"
 else
 	ARCHSFX=""
+fi
+
+MKISOFS=$(which mkisofs)
+if [ -z "$MKISOFS" ]; then
+	echo "Error: mkisofs not found, this tool is required." 1>&2
+	exit 1
 fi
 
 export DARWINXREF_DB_FILE="$DARWIN_BUILDROOT/$XREFDB"

--- a/darwinbuild/darwinmaster.in
+++ b/darwinbuild/darwinmaster.in
@@ -182,7 +182,7 @@ done
 ### Remove extraneous files
 ###
 echo "Pruning ..."
-find "$DESTDIR" -type f \( -name '*.[ch]' -or -name '*.cp' -or -name '*.cpp' \) -print -exec rm -f {} ';'
+find "$DESTDIR" -type f \( -name '*.[ch]' -or -name '*.cp' -or -name '*.cpp' \) -exec rm -f {} ';'
 rm -Rf "$DESTDIR/Applications/Xcode.app"
 rm -Rf "$DESTDIR/AppleInternal"
 rm -Rf "$DESTDIR/Developer"

--- a/darwinbuild/darwinmaster.in
+++ b/darwinbuild/darwinmaster.in
@@ -283,9 +283,6 @@ elif [ "$ARCH" == "i386" -o -z "$ARCH" ]; then
 	mkdir -p /mnt
 	mount -t hfs -o perm "${DEV}s${SLICE}" /mnt
 	ditto -rsrc "$DESTDIR" /mnt
-	bless -folder /mnt/System/Library/CoreServices \
-	      -bootinfo /mnt/usr/standalone/ppc/bootx.bootinfo \
-	      -label "$VOLNAME"
 	umount /mnt
 	hdiutil eject "$DEV"
 	mv "$ISO.dmg" "$ISO"

--- a/darwinbuild/darwinmaster.in
+++ b/darwinbuild/darwinmaster.in
@@ -284,6 +284,7 @@ elif [ "$ARCH" == "i386" -o -z "$ARCH" ]; then
 	mount -t hfs -o perm "${DEV}s${SLICE}" /mnt
 	ditto -rsrc "$DESTDIR" /mnt
 	umount /mnt
+	rmdir /mnt
 	hdiutil eject "$DEV"
 	mv "$ISO.dmg" "$ISO"
 fi

--- a/darwinbuild/darwinmaster.in
+++ b/darwinbuild/darwinmaster.in
@@ -169,7 +169,7 @@ DESTDIR=$(hdiutil attach "$DMG" \
 ###
 ### Copy roots necessary for booting / installation onto disk image
 ###
-cd "$DESTDIR" || exit
+pushd "$DESTDIR" > /dev/null || exit
 chown root:admin "$DESTDIR"
 chmod 1775 "$DESTDIR"
 
@@ -288,3 +288,6 @@ elif [ "$ARCH" == "i386" -o -z "$ARCH" ]; then
 	hdiutil eject "$DEV"
 	mv "$ISO.dmg" "$ISO"
 fi
+
+popd > /dev/null
+hdiutil eject "$DESTDIR"

--- a/darwinbuild/darwinmaster.in
+++ b/darwinbuild/darwinmaster.in
@@ -39,18 +39,15 @@
 # Chuck Remes       <cremes@opendarwin.org>
 
 function PrintUsage() {
-	cat 1>&2 <<- EOB
-usage: $(basename "$0") [-arch=arch] <volname>
-       arch = {ppc, i386}
+	cat 1>&2 <<-EOB
+usage: $(basename "$0") <volname>
 EOB
 	exit 1
 }
 
 for ARG in "$@"; do
 	if [ "$VOLNAME" == "" ]; then
-		if [ "${ARG/=*/}" == "-arch" ]; then
-			ARCH="${ARCH/*=/}"
-		elif [ "${ARG:0:1}" != "-" ]; then
+		if [ "${ARG:0:1}" != "-" ]; then
 			VOLNAME="$ARG"
 		else
 			PrintUsage "$0"
@@ -60,8 +57,7 @@ for ARG in "$@"; do
 	fi
 done
 
-if [ "$ARCH" != "" -a "$ARCH" != "ppc" -a "$ARCH" != "i386" \
-	-o "$VOLNAME" == "" ]; then
+if [ "$VOLNAME" == "" ]; then
 	PrintUsage "$0"
 fi
 
@@ -88,11 +84,6 @@ CDR="/tmp/$VOLNAME.cdr"
 ISO="/tmp/$VOLNAME.iso"
 PKGDIR="$DARWIN_BUILDROOT/Packages"
 SIZE="650m"
-if [ ! -z "$ARCH" ]; then
-	ARCHSFX="_$ARCH"
-else
-	ARCHSFX=""
-fi
 
 if [ -z "$MKISOFS" ]; then
     MKISOFS=$(which mkisofs)
@@ -144,13 +135,6 @@ export DARWINBUILD_BUILD="$build"
 ###
 "$DATADIR/packageRoots"
 
-###
-### Update thin packages
-###
-if [ ! -z "$ARCH" ]; then
-	"$DATADIR/thinPackages" "$ARCH"
-fi
-
 
 ###
 ### Mount a disk image, create if necessary
@@ -200,21 +184,21 @@ echo "(Not implemented, making no changes)"
 ###
 ### Copy installation packages
 ###
-mkdir -p "$DESTDIR/System/Installation/BinaryDrivers${ARCHSFX}"
+mkdir -p "$DESTDIR/System/Installation/BinaryDrivers"
 echo "Copying binary drivers ..."
-for X in $DARWIN_BUILDROOT/BinaryDrivers${ARCHSFX}/*-*.tar.bz2 ; do
-	Y="$DESTDIR"/System/Installation/BinaryDrivers${ARCHSFX}/$(basename $X)
+for X in $DARWIN_BUILDROOT/BinaryDrivers/*-*.tar.bz2 ; do
+	Y="$DESTDIR"/System/Installation/BinaryDrivers/$(basename $X)
 	if [ $X -nt $Y ]; then
 		cp $X $Y
 	fi
 done
 
 echo "Copying packages ..."
-mkdir -p "$DESTDIR"/System/Installation/Packages${ARCHSFX}
-for X in $DARWIN_BUILDROOT/Packages${ARCHSFX}/*-*.tar.bz2 ; do
+mkdir -p "$DESTDIR"/System/Installation/Packages
+for X in $DARWIN_BUILDROOT/Packages/*-*.tar.bz2 ; do
 	f=$(basename $X)
 	if [ "${f/-*/}" != "DarwinInstaller" ]; then
-	Y="$DESTDIR"/System/Installation/Packages${ARCHSFX}/$(basename $X)
+	Y="$DESTDIR"/System/Installation/Packages/$(basename $X)
 	if [ $X -nt $Y ]; then
 		echo $f
 		cp $X $Y
@@ -223,71 +207,48 @@ for X in $DARWIN_BUILDROOT/Packages${ARCHSFX}/*-*.tar.bz2 ; do
 done
 
 ###
-### Architecture-specific boot setup
+### Create a bootable ISO filesystem
 ###
-if [ "$ARCH" == "ppc" ]; then
-	###
-	### Bless the volume for powerpc booting
-	###
-	echo "Blessing Volume ..."
-	bless   --verbose \
-		--label "$VOLNAME" \
-		--folder "$DESTDIR/System/Library/CoreServices" \
-		--bootinfo "$DESTDIR/usr/standalone/ppc/bootx.bootinfo"
+ditto "$DESTDIR/usr/standalone/i386" /tmp/i386
+rm -f "$ISO.boot"
+$MKISOFS -R \
+	-V "$VOLNAME" \
+	-no-emul-boot \
+	-T \
+	-J \
+	-c boot.cat \
+	-b cdboot \
+	-hide-joliet-trans-tbl \
+	-quiet \
+	-o "$ISO.boot" \
+	/tmp/i386
+SECTORS=$(du "$ISO.boot" | tail -1 | awk '{print $1}')
 
-	### Generate CDR image
-	rm -f "$CDR"
-        hdiutil convert \
-		"$DMG" \
-		-format UDTO \
-                -o "$CDR"
+###
+### Create a hybrid image
+###
+rm -f "$ISO.dmg"
+hdiutil create "$ISO.dmg" -size "$SIZE" -layout NONE
+DEV=$(hdid -nomount "$ISO.dmg" | tail -1 | awk '{print $1}')
+RDEV=$(echo $DEV | sed s/disk/rdisk/)
 
+pdisk "$RDEV" -initialize
+BLOCKS=$(pdisk "$RDEV" -dump | grep 2: | awk -F" " '{print $4}')
 
-elif [ "$ARCH" == "i386" -o -z "$ARCH" ]; then
-	###
-	### Create a bootable ISO filesystem
-	###
-	ditto "$DESTDIR/usr/standalone/i386" /tmp/i386
-	rm -f "$ISO.boot"
-	$MKISOFS -R \
-		-V "$VOLNAME" \
-		-no-emul-boot \
-		-T \
-		-J \
-		-c boot.cat \
-		-b cdboot \
-		-hide-joliet-trans-tbl \
-		-quiet \
-		-o "$ISO.boot" \
-		/tmp/i386
-	SECTORS=$(du "$ISO.boot" | tail -1 | awk '{print $1}')
+pdisk "$RDEV" -createPartition "$VOLNAME" Apple_HFS $SECTORS $(($BLOCKS - $SECTORS))
+SLICE=$(pdisk "$RDEV" -dump | grep "$VOLNAME" | awk -F: '{print $1}' | awk -F" " '{print $1}')
 
-	###
-	### Create a hybrid image
-	###
-	rm -f "$ISO.dmg"
-	hdiutil create "$ISO.dmg" -size "$SIZE" -layout NONE
-	DEV=$(hdid -nomount "$ISO.dmg" | tail -1 | awk '{print $1}')
-	RDEV=$(echo $DEV | sed s/disk/rdisk/)
+### Copy ISO boot data onto the disk image
+dd if="$ISO.boot" of="$RDEV" skip=64 seek=64 bs=512
 
-	pdisk "$RDEV" -initialize
-	BLOCKS=$(pdisk "$RDEV" -dump | grep 2: | awk -F" " '{print $4}')
-
-	pdisk "$RDEV" -createPartition "$VOLNAME" Apple_HFS $SECTORS $(($BLOCKS - $SECTORS))
-	SLICE=$(pdisk "$RDEV" -dump | grep "$VOLNAME" | awk -F: '{print $1}' | awk -F" " '{print $1}')
-
-	### Copy ISO boot data onto the disk image
-	dd if="$ISO.boot" of="$RDEV" skip=64 seek=64 bs=512
-
-	newfs_hfs -v "$VOLNAME" "${RDEV}s${SLICE}"
-	mkdir -p /mnt
-	mount -t hfs -o perm "${DEV}s${SLICE}" /mnt
-	ditto -rsrc "$DESTDIR" /mnt
-	umount /mnt
-	rmdir /mnt
-	hdiutil eject "$DEV"
-	mv "$ISO.dmg" "$ISO"
-fi
+newfs_hfs -v "$VOLNAME" "${RDEV}s${SLICE}"
+mkdir -p /mnt
+mount -t hfs -o perm "${DEV}s${SLICE}" /mnt
+ditto -rsrc "$DESTDIR" /mnt
+umount /mnt
+rmdir /mnt
+hdiutil eject "$DEV"
+mv "$ISO.dmg" "$ISO"
 
 popd > /dev/null
 hdiutil eject "$DESTDIR"

--- a/darwinbuild/darwinmaster.in
+++ b/darwinbuild/darwinmaster.in
@@ -201,7 +201,7 @@ rmdir "$DESTDIR/Applications" 2> /dev/null
 ### Modify the root password to blank
 ###
 echo "Modifying Root Password ..."
-nicl -raw "$DESTDIR/var/db/netinfo/local.nidb" -create /users/root passwd ''
+echo "(Not implemented, making no changes)"
 
 ###
 ### Copy installation packages

--- a/darwinbuild/darwinmaster.in
+++ b/darwinbuild/darwinmaster.in
@@ -94,7 +94,10 @@ else
 	ARCHSFX=""
 fi
 
-MKISOFS=$(which mkisofs)
+if [ -z "$MKISOFS" ]; then
+    MKISOFS=$(which mkisofs)
+fi
+
 if [ -z "$MKISOFS" ]; then
 	echo "Error: mkisofs not found, this tool is required." 1>&2
 	exit 1

--- a/darwinbuild/darwinmaster.in
+++ b/darwinbuild/darwinmaster.in
@@ -189,11 +189,13 @@ export -n TMPDIR
 ###
 echo "Pruning ..."
 find "$DESTDIR" -type f \( -name '*.[ch]' -or -name '*.cp' -or -name '*.cpp' \) -print -exec rm -f {} ';'
+rm -Rf "$DESTDIR/Applications/Xcode.app"
 rm -Rf "$DESTDIR/AppleInternal"
 rm -Rf "$DESTDIR/Developer"
 rm -Rf "$DESTDIR/usr/local"
 rm -Rf "$DESTDIR/usr/share/doc"
 rm -Rf "$DESTDIR"/usr/share/man/man3/*
+rmdir "$DESTDIR/Applications" 2> /dev/null
 
 ###
 ### Modify the root password to blank

--- a/darwinbuild/darwinmaster.in
+++ b/darwinbuild/darwinmaster.in
@@ -182,7 +182,7 @@ done
 ### Remove extraneous files
 ###
 echo "Pruning ..."
-find "$DESTDIR" -type f \( -name '*.[ch]' -or -name '*.cp' -or -name '*.cpp' \) -exec rm -f {} ';'
+find "$DESTDIR" -type f \( -name '*.[ch]' -or -name '*.cp' -or -name '*.cpp' \) -print0 | xargs -0 rm -f
 rm -Rf "$DESTDIR/Applications/Xcode.app"
 rm -Rf "$DESTDIR/AppleInternal"
 rm -Rf "$DESTDIR/Developer"

--- a/darwinbuild/darwinmaster.in
+++ b/darwinbuild/darwinmaster.in
@@ -198,11 +198,11 @@ mkdir -p "$DESTDIR"/System/Installation/Packages
 for X in $DARWIN_BUILDROOT/Packages/*-*.tar.bz2 ; do
 	f=$(basename $X)
 	if [ "${f/-*/}" != "DarwinInstaller" ]; then
-	Y="$DESTDIR"/System/Installation/Packages/$(basename $X)
-	if [ $X -nt $Y ]; then
-		echo $f
-		cp $X $Y
-	fi
+		Y="$DESTDIR"/System/Installation/Packages/$(basename $X)
+		if [ $X -nt $Y ]; then
+			echo $f
+			cp $X $Y
+		fi
 	fi
 done
 

--- a/darwinbuild/darwinmaster.in
+++ b/darwinbuild/darwinmaster.in
@@ -179,20 +179,6 @@ for Project in $("$DARWINXREF" group boot) ; do
 done
 
 ###
-### Generate the mkext cache
-###
-echo "Generating MKext ..."
-
-export TMPDIR="$DESTDIR/private/tmp"
-if [ -z "$ARCH" ]; then
-	KEXTARCH="-a ppc -a i386"
-else
-	KEXTARCH="-a $ARCH"
-fi
-kextcache $KEXTARCH -k -K "$DESTDIR/mach_kernel" -m "$DESTDIR/System/Library/Extensions.mkext" "$DESTDIR/System/Library/Extensions"
-export -n TMPDIR
-
-###
 ### Remove extraneous files
 ###
 echo "Pruning ..."


### PR DESCRIPTION
This PR fixes the `darwinmaster` script such that it now correctly generates a bootable ISO. I have tested this on macOS High Sierra build 17A352a. Note that the `mkisofs` tool must be installed and in the PATH before this tool will succeed (previously it checked for it at a hard-coded path).