### PR TITLE
dtrace_host patches

### DIFF
--- a/patches/dtrace-209.50.12.host-install.p1.patch
+++ b/patches/dtrace-209.50.12.host-install.p1.patch
@@ -1,0 +1,58 @@
+diff --git a/dtrace.xcodeproj/project.pbxproj b/dtrace.xcodeproj/project.pbxproj
+index c97d7b6..1900353 100644
+--- a/dtrace.xcodeproj/project.pbxproj
++++ b/dtrace.xcodeproj/project.pbxproj
+@@ -5792,7 +5792,7 @@
+ 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+ 				GCC_MODEL_TUNING = G5;
+ 				GCC_OPTIMIZATION_LEVEL = 0;
+-				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
++				INSTALL_PATH = /usr/local/bin;
+ 				OTHER_CFLAGS = (
+ 					"-D_INT64_TYPE",
+ 					"-D_LONGLONG_TYPE",
+@@ -5822,7 +5822,7 @@
+ 				);
+ 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+ 				GCC_MODEL_TUNING = G5;
+-				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
++				INSTALL_PATH = /usr/local/bin;
+ 				OTHER_CFLAGS = (
+ 					"-D_INT64_TYPE",
+ 					"-D_LONGLONG_TYPE",
+@@ -5854,7 +5854,7 @@
+ 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+ 				GCC_MODEL_TUNING = G5;
+ 				GCC_OPTIMIZATION_LEVEL = 0;
+-				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
++				INSTALL_PATH = /usr/local/bin;
+ 				OTHER_CFLAGS = (
+ 					"-D_INT64_TYPE",
+ 					"-D_LONGLONG_TYPE",
+@@ -5883,7 +5883,7 @@
+ 				);
+ 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+ 				GCC_MODEL_TUNING = G5;
+-				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
++				INSTALL_PATH = /usr/local/bin;
+ 				OTHER_CFLAGS = (
+ 					"-D_INT64_TYPE",
+ 					"-D_LONGLONG_TYPE",
+@@ -5949,7 +5949,7 @@
+ 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+ 				GCC_MODEL_TUNING = G5;
+ 				GCC_OPTIMIZATION_LEVEL = 0;
+-				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
++				INSTALL_PATH = /usr/local/bin;
+ 				OTHER_CFLAGS = (
+ 					"-D_INT64_TYPE",
+ 					"-D_LONGLONG_TYPE",
+@@ -5979,7 +5979,7 @@
+ 				);
+ 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+ 				GCC_MODEL_TUNING = G5;
+-				INSTALL_PATH = "$(DT_TOOLCHAIN_DIR)/usr/local/bin";
++				INSTALL_PATH = /usr/local/bin;
+ 				OTHER_CFLAGS = (
+ 					"-D_INT64_TYPE",
+ 					"-D_LONGLONG_TYPE",

--- a/patches/xnu-3789.51.2.paths.p1.patch
+++ b/patches/xnu-3789.51.2.paths.p1.patch
@@ -1,0 +1,54 @@
+diff --git a/bsd/sys/make_symbol_aliasing.sh b/bsd/sys/make_symbol_aliasing.sh
+index bfddb2d..a1e694a 100755
+--- a/bsd/sys/make_symbol_aliasing.sh
++++ b/bsd/sys/make_symbol_aliasing.sh
+@@ -34,8 +34,8 @@ fi
+ SDKROOT="$1"
+ OUTPUT="$2"
+ 
+-if [ ! -x "/usr/local/libexec/availability.pl" ] ; then
+-    echo "Unable to locate /usr/local/libexec/availability.pl (or not executable)" >&2
++if [ ! -x "${RC_BuildRoot}/usr/local/libexec/availability.pl" ] ; then
++    echo "Unable to locate ${RC_BuildRoot}/usr/local/libexec/availability.pl (or not executable)" >&2
+     exit 1
+ fi
+ 	    
+@@ -74,7 +74,7 @@ cat <<EOF
+ 
+ EOF
+ 
+-for ver in $(/usr/local/libexec/availability.pl --ios) ; do
++for ver in $(${RC_BuildRoot}/usr/local/libexec/availability.pl --ios) ; do
+     ver_major=${ver%.*}
+     ver_minor=${ver#*.}
+     value=$(printf "%d%02d00" ${ver_major} ${ver_minor})
+@@ -87,7 +87,7 @@ for ver in $(/usr/local/libexec/availability.pl --ios) ; do
+     echo ""
+ done
+ 
+-for ver in $(/usr/local/libexec/availability.pl --macosx) ; do
++for ver in $(${RC_BuildRoot}/usr/local/libexec/availability.pl --macosx) ; do
+     set -- $(echo "$ver" | tr '.' ' ')
+     ver_major=$1
+     ver_minor=$2
+diff --git a/makedefs/MakeInc.cmd b/makedefs/MakeInc.cmd
+index 0619a33..b43f856 100644
+--- a/makedefs/MakeInc.cmd
++++ b/makedefs/MakeInc.cmd
+@@ -103,13 +103,13 @@ ifeq ($(DSYMUTIL),)
+ 	export DSYMUTIL := $(shell $(XCRUN) -sdk $(SDKROOT) -find dsymutil)
+ endif
+ ifeq ($(CTFCONVERT),)
+-	export CTFCONVERT := $(shell $(XCRUN) -sdk $(SDKROOT) -find ctfconvert)
++	export CTFCONVERT := $(RC_BuildRoot)/usr/local/bin/ctfconvert
+ endif
+ ifeq ($(CTFMERGE),)
+-	export CTFMERGE :=  $(shell $(XCRUN) -sdk $(SDKROOT) -find ctfmerge)
++	export CTFMERGE := $(RC_BuildRoot)/usr/local/bin/ctfmerge
+ endif
+ ifeq ($(CTFINSERT),)
+-	export CTFINSERT := $(shell $(XCRUN) -sdk $(SDKROOT) -find ctf_insert)
++	export CTFINSERT := $(RC_BuildRoot)/usr/local/bin/ctf_insert
+ endif
+ ifeq ($(NMEDIT),)
+ 	export NMEDIT := $(shell $(XCRUN) -sdk $(SDKROOT) -find nmedit)


### PR DESCRIPTION
This PR contains two patches, one to `dtrace_host` and one to `xnu` (and its alias, `xnu_headers`), that fix the building of `xnu` when not using the chroot. These patches will come in very useful now that out-of-chroot building is now the default. A PR to PureDarwin-System-Plist will follow shortly.

As always for patches, a copyright header was not added to the patches, as the file format does not support them.