### PR TITLE
General darwinbuild cleanup

### DIFF
--- a/darwinbuild/darwinbuild.in
+++ b/darwinbuild/darwinbuild.in
@@ -222,7 +222,7 @@ EOF
 ###
 CheckDarwinBuildRoot
 BuildRoot="$DARWIN_BUILDROOT/BuildRoot"
-BuildRoot=$(realpath $BuildRoot)
+BuildRoot=$(realpath "$BuildRoot")
 export DARWINXREF_DB_FILE="$DARWIN_BUILDROOT/$XREFDB"
 
 ###

--- a/darwinbuild/darwinbuild.in
+++ b/darwinbuild/darwinbuild.in
@@ -222,6 +222,7 @@ EOF
 ###
 CheckDarwinBuildRoot
 BuildRoot="$DARWIN_BUILDROOT/BuildRoot"
+BuildRoot=$(realpath $BuildRoot)
 export DARWINXREF_DB_FILE="$DARWIN_BUILDROOT/$XREFDB"
 
 ###

--- a/darwinbuild/darwinbuild.in
+++ b/darwinbuild/darwinbuild.in
@@ -746,9 +746,9 @@ cat <<-EOF > $SCRIPT
 	echo '    Build action:         $action'
 	echo "    Build number:         $build"
 	echo "    Host kernel version:  \$(uname -v 2>/dev/null)"
-	echo "    cc version:           \$(gcc -v 2>&1 | tail -n 1 2>/dev/null)"
+	echo "    cc version:           \$(gcc -v 2>&1 | grep version 2>/dev/null)"
 	# Panther cctools unlinks -o target, so don't use /dev/null
-	echo "    cctools version:      \$(as -v -o /.devnull < /dev/null 2>&1 | cut -c 22- 2>/dev/null)"
+	echo "    cctools version:      \$(as -v -o /.devnull < /dev/null 2>&1 | grep version | grep -v dwarf-version 2>/dev/null)"
 EOF
 if [ "$logdeps" == "YES" ]; then
 	if [ "$USE_CHROOT" == "YES" ]; then
@@ -777,7 +777,7 @@ fi
 
 if [ "$buildtool" == "xcodebuild" ]; then
 cat <<-EOF >> $SCRIPT
-	echo "    xcode version:        \$(sh -c \\\"$buildtool -version\\\")"
+	echo "    xcode version:        \$(sh -c \\\"$buildtool -version\\\" | head -1 2> /dev/null)"
 EOF
 else
 cat <<-EOF >> $SCRIPT

--- a/darwintrace/darwintrace.c
+++ b/darwintrace/darwintrace.c
@@ -128,14 +128,6 @@ static inline char* darwintrace_redirect_path(const char* path) {
 		dprintf("darwintrace: redirect %s -> %s\n", path, redirpath);
 	}
 
-	if (path[0] == '/' && darwintrace_except(path)) {
-		asprintf(&redirpath, "%s%s%s", darwintrace_redirect, (*path == '/' ? "" : "/"), path);
-		if (access(redirpath, F_OK) != 0) {
-			free(redirpath);
-			redirpath = (char *)path;
-		}
-	}
-
 	return redirpath;
 }
 


### PR DESCRIPTION
This PR does three things:

1. It removes unused, non-working code from `darwintrace`. I originally included it to abstract away differences between the chroot and non-chroot environments from the build tool. However, this technique didn't work.
2. It updates the algorithms used to print the version information of the compilers to match what is output by modern versions of the Xcode tools.
3. It uses the real (non-symlinked) version of the path to the build root when building outside the chroot.