### PR TITLE
Add permissions fixup code to darwinmaster

### DIFF
--- a/darwinbuild/darwinmaster.in
+++ b/darwinbuild/darwinmaster.in
@@ -206,6 +206,14 @@ for X in $DARWIN_BUILDROOT/Packages/*-*.tar.bz2 ; do
 	fi
 done
 
+# Now chown to root:wheel, if possible. (Build invocations run as a
+# non-privileged user will propagate that user's uid/gid to the build
+# outputs it generates.)
+if [ $InstallSelfBuiltRoots -eq 1 -a $EUID -eq 0 ]; then
+	echo "Setting file ownership to root/wheel ..."
+	chown -R root:wheel "$DESTDIR"
+fi
+
 ###
 ### Create a bootable ISO filesystem
 ###

--- a/darwinbuild/darwinmaster.in
+++ b/darwinbuild/darwinmaster.in
@@ -209,7 +209,7 @@ done
 # Now chown to root:wheel, if possible. (Build invocations run as a
 # non-privileged user will propagate that user's uid/gid to the build
 # outputs it generates.)
-if [ $InstallSelfBuiltRoots -eq 1 -a $EUID -eq 0 ]; then
+if [ $EUID -eq 0 ]; then
 	echo "Setting file ownership to root/wheel ..."
 	chown -R root:wheel "$DESTDIR"
 fi


### PR DESCRIPTION
This is required because the contents of the install ISO must be owned by root/wheel. If darwinbuild is run as a non-root user, it will propagate that user's uid/gid to the build outputs it generates.

This method was the best way I could think of to ensure that the files on the final ISO image are owned by root, without breaking the changes made in #20 to allow for code-signing during the build.