### PR TITLE
Fix path manipulation

### DIFF
--- a/darwinbuild/darwinbuild.in
+++ b/darwinbuild/darwinbuild.in
@@ -198,7 +198,6 @@ EOF
 ###
 CheckDarwinBuildRoot
 BuildRoot="$DARWIN_BUILDROOT/BuildRoot"
-BuildRoot=$(realpath "$BuildRoot")
 export DARWINXREF_DB_FILE="$DARWIN_BUILDROOT/$XREFDB"
 
 ###
@@ -214,6 +213,8 @@ if [ -d $DMGFILE ]; then
 	    exit 70
 	fi
     fi
+
+    BuildRoot=$(cd "$BuildRoot" && pwd -P)
 fi
 
 ###


### PR DESCRIPTION
The previous algorithm (committed in c3b8575084c468d75ea4dbf92435fd5eb8b31655) would not work on a stock macOS system (it depended on coreutils, which I happened to have installed when I first wrote it), and it would also cause failures if the build root image was not mounted (which therefore broke mounting the image to begin with). Both problems should now be fixed. Sorry about that!