### PR TITLE
General fixes regarding build root disk image handling

### DIFF
--- a/darwinbuild/darwinbuild.in
+++ b/darwinbuild/darwinbuild.in
@@ -158,12 +158,15 @@ if [ "$1" == "-init" ]; then
 	if [ "$3" == "-nodmg" ]; then
 		mkdir -p BuildRoot
 	else
-		echo "Creating build root disk image ..."
 		DMGVOLUME="BuildRoot_${build}_${stamp}"
-		hdiutil create -size 1t -fs HFSX -quiet -uid $(id -u) -gid $(id -g) \
-			-volname $DMGVOLUME \
-			$DMGFILE
-		ln -s "/Volumes/${DMGVOLUME}" BuildRoot
+
+		if [ ! -f "$DMGFILE" ]; then
+			echo "Creating build root disk image ..."
+			hdiutil create -size 1t -fs HFSX -quiet -uid $(id -u) -gid $(id -g) \
+				-volname $DMGVOLUME \
+				$DMGFILE
+			ln -s "/Volumes/${DMGVOLUME}" BuildRoot
+		fi
 	fi
 
 	###

--- a/darwinbuild/darwinbuild.in
+++ b/darwinbuild/darwinbuild.in
@@ -158,7 +158,7 @@ if [ "$1" == "-init" ]; then
 		mkdir -p BuildRoot
 	else
 		DMGVOLUME="BuildRoot_${build}"
-		if [ -d "$DMGVOLUME" ]; then
+		if [ -d "/Volumes/$DMGVOLUME" ]; then
 			stamp=$(date +'%Y%m%d%H%M%S')
 			DMGVOLUME="BuildRoot_${build}_${stamp}"
 		fi

--- a/darwinbuild/darwinbuild.in
+++ b/darwinbuild/darwinbuild.in
@@ -154,11 +154,14 @@ if [ "$1" == "-init" ]; then
 	###
 	### Create the build root
 	###
-	stamp=$(date +'%Y%m%d%H%M%S')
 	if [ "$3" == "-nodmg" ]; then
 		mkdir -p BuildRoot
 	else
-		DMGVOLUME="BuildRoot_${build}_${stamp}"
+		DMGVOLUME="BuildRoot_${build}"
+		if [ -d "$DMGVOLUME" ]; then
+			stamp=$(date +'%Y%m%d%H%M%S')
+			DMGVOLUME="BuildRoot_${build}_${stamp}"
+		fi
 
 		if [ ! -f "$DMGFILE" ]; then
 			echo "Creating build root disk image ..."

--- a/darwinbuild/darwinbuild.in
+++ b/darwinbuild/darwinbuild.in
@@ -163,7 +163,7 @@ if [ "$1" == "-init" ]; then
 			DMGVOLUME="BuildRoot_${build}_${stamp}"
 		fi
 
-		if [ ! -f "$DMGFILE" ]; then
+		if [ ! -e "$DMGFILE" ]; then
 			echo "Creating build root disk image ..."
 			hdiutil create -size 1t -fs HFSX -quiet -uid $(id -u) -gid $(id -g) \
 				-volname $DMGVOLUME \


### PR DESCRIPTION
Now, the build root image will not be unnecessarily re-created (which, while harmless on its own, causes broken duplicate symlinks to pile up in the root directory of the build image as a side effect of `ln -s`). In addition, the timestamp will be omitted from the volume name when possible.