### PR TITLE
Add the BuildRoot as an additional Xcode SDK

### DIFF
--- a/darwinbuild/darwinbuild.in
+++ b/darwinbuild/darwinbuild.in
@@ -684,6 +684,7 @@ fi
 build_string=""
 if [ "$buildtool" == "xcodebuild" -a $INSTALL_XCODE == "YES" ]; then
 	build_string="-sdk $platform"
+	build_string="$build_string ADDITIONAL_SDKS=\"$BuildRoot\""
 fi
 if [ "$buildtool" == "xcodebuild" -a "$target" != "" ]; then
 	build_string="$build_string -target \"$target\""


### PR DESCRIPTION
Once this PR is merged use of the `$(RC_BuildRoot)` variable will no longer be required for Xcode projects referencing private headers to build. (It may still be needed for Make-based projects, however.)