### PR TITLE
Make darwinbuild -headers honor a custom target in the plist

### DIFF
--- a/darwinbuild/darwinbuild.in
+++ b/darwinbuild/darwinbuild.in
@@ -390,7 +390,7 @@ alias=$($DARWINXREF original "$projnam")
 #
 # Look for an alternate target in the database
 #
-if [ "$target" == "" -a "$action" == "install" ]; then
+if [ "$target" == "" ]; then
 	target=$($DARWINXREF target "$projnam")
 fi
 


### PR DESCRIPTION
Previously, a custom target would only be used when doing a full build and install.