### PR TITLE
Fix installation of shell script tools

### DIFF
--- a/darwinbuild.xcodeproj/project.pbxproj
+++ b/darwinbuild.xcodeproj/project.pbxproj
@@ -1992,7 +1992,7 @@
 			files = (
 			);
 			inputPaths = (
-				"$(BUILT_PRODUCT_SDIR)/darwinbuild",
+				"$(BUILT_PRODUCTS_DIR)/darwinbuild",
 			);
 			outputPaths = (
 				"$(DSTROOT)/usr/local/bin/darwinbuild",

--- a/darwinbuild.xcodeproj/project.pbxproj
+++ b/darwinbuild.xcodeproj/project.pbxproj
@@ -1361,6 +1361,7 @@
 			buildPhases = (
 				7227AC001098D78C00BE33D7 /* ShellScript */,
 				7227AC011098D78C00BE33D7 /* ShellScript */,
+				1F71A4FE2030F7A700020E2F /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1377,6 +1378,7 @@
 			buildPhases = (
 				7227AC0D1098D84600BE33D7 /* ShellScript */,
 				7227AC0E1098D84600BE33D7 /* ShellScript */,
+				1F71A4FF2030F81C00020E2F /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1393,6 +1395,7 @@
 			buildPhases = (
 				7227AC161098D8DB00BE33D7 /* ShellScript */,
 				7227AC171098D8DB00BE33D7 /* ShellScript */,
+				1F71A5002030F83D00020E2F /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1409,6 +1412,7 @@
 			buildPhases = (
 				7227AC1F1098DB9200BE33D7 /* ShellScript */,
 				7227AC201098DB9200BE33D7 /* ShellScript */,
+				1F71A5012030F86400020E2F /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1425,6 +1429,7 @@
 			buildPhases = (
 				7227AC281098DBDF00BE33D7 /* ShellScript */,
 				7227AC291098DBDF00BE33D7 /* ShellScript */,
+				1F71A5022030F88300020E2F /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1995,6 +2000,86 @@
 			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
 			shellScript = "/bin/cp $BUILT_PRODUCTS_DIR/darwinbuild $DSTROOT/usr/local/bin";
+			showEnvVarsInLog = 0;
+		};
+		1F71A4FE2030F7A700020E2F /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 8;
+			files = (
+			);
+			inputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/darwinmaster",
+			);
+			outputPaths = (
+				"$(DSTROOT)/usr/local/bin/darwinmaster",
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+			shellPath = /bin/sh;
+			shellScript = "/bin/cp $BUILT_PRODUCTS_DIR/darwinmaster $DSTROOT/usr/local/bin/darwinmaster";
+			showEnvVarsInLog = 0;
+		};
+		1F71A4FF2030F81C00020E2F /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 8;
+			files = (
+			);
+			inputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/packageRoots",
+			);
+			outputPaths = (
+				"$(DATDIR)/packageRoots",
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+			shellPath = /bin/sh;
+			shellScript = "/bin/cp $BUILT_PRODUCTS_DIR/packageRoots $DATDIR/packageRoots";
+			showEnvVarsInLog = 0;
+		};
+		1F71A5002030F83D00020E2F /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 8;
+			files = (
+			);
+			inputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/thinPackages",
+			);
+			outputPaths = (
+				"$(DATDIR)/thinPackages",
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+			shellPath = /bin/sh;
+			shellScript = "/bin/cp $BUILT_PRODUCTS_DIR/thinPackages $DATDIR/thinPackages";
+			showEnvVarsInLog = 0;
+		};
+		1F71A5012030F86400020E2F /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 8;
+			files = (
+			);
+			inputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/installXcode",
+			);
+			outputPaths = (
+				"$(DATDIR)/installXcode",
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+			shellPath = /bin/sh;
+			shellScript = "/bin/cp $BUILT_PRODUCTS_DIR/installXcode $DATDIR/installXcode";
+			showEnvVarsInLog = 0;
+		};
+		1F71A5022030F88300020E2F /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 8;
+			files = (
+			);
+			inputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/installXcode32",
+			);
+			outputPaths = (
+				"$(DATDIR)/installXcode32",
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+			shellPath = /bin/sh;
+			shellScript = "mkdir -p $DATDIR\n/bin/cp $BUILT_PRODUCTS_DIR/installXcode32 $DATDIR/installXcode32";
 			showEnvVarsInLog = 0;
 		};
 		7227AB8F1098A89700BE33D7 /* Run Script */ = {

--- a/darwinbuild.xcodeproj/project.pbxproj
+++ b/darwinbuild.xcodeproj/project.pbxproj
@@ -1999,7 +1999,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
-			shellScript = "/bin/cp $BUILT_PRODUCTS_DIR/darwinbuild $DSTROOT/usr/local/bin";
+			shellScript = "mkdir -p $DSTROOT/usr/local/bin\n/bin/cp $BUILT_PRODUCTS_DIR/darwinbuild $DSTROOT/usr/local/bin";
 			showEnvVarsInLog = 0;
 		};
 		1F71A4FE2030F7A700020E2F /* ShellScript */ = {
@@ -2015,7 +2015,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
-			shellScript = "/bin/cp $BUILT_PRODUCTS_DIR/darwinmaster $DSTROOT/usr/local/bin/darwinmaster";
+			shellScript = "mkdir -p $DSTROOT/usr/local/bin\n/bin/cp $BUILT_PRODUCTS_DIR/darwinmaster $DSTROOT/usr/local/bin/darwinmaster";
 			showEnvVarsInLog = 0;
 		};
 		1F71A4FF2030F81C00020E2F /* ShellScript */ = {
@@ -2027,11 +2027,11 @@
 				"$(BUILT_PRODUCTS_DIR)/packageRoots",
 			);
 			outputPaths = (
-				"$(DATDIR)/packageRoots",
+				"$(DSTROOT)/$(DATDIR)/darwinbuild/packageRoots",
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
-			shellScript = "/bin/cp $BUILT_PRODUCTS_DIR/packageRoots $DATDIR/packageRoots";
+			shellScript = "mkdir -p $DSTROOT/$DATDIR/darwinbuild\n/bin/cp $BUILT_PRODUCTS_DIR/packageRoots $DSTROOT/$DATDIR/darwinbuild/packageRoots";
 			showEnvVarsInLog = 0;
 		};
 		1F71A5002030F83D00020E2F /* ShellScript */ = {
@@ -2043,11 +2043,11 @@
 				"$(BUILT_PRODUCTS_DIR)/thinPackages",
 			);
 			outputPaths = (
-				"$(DATDIR)/thinPackages",
+				"$(DSTROOT)/$(DATDIR)/darwinbuild/thinPackages",
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
-			shellScript = "/bin/cp $BUILT_PRODUCTS_DIR/thinPackages $DATDIR/thinPackages";
+			shellScript = "mkdir -p $DSTROOT/$DATDIR/darwinbuild\n/bin/cp $BUILT_PRODUCTS_DIR/thinPackages $DSTROOT/$DATDIR/darwinbuild/thinPackages";
 			showEnvVarsInLog = 0;
 		};
 		1F71A5012030F86400020E2F /* ShellScript */ = {
@@ -2059,11 +2059,11 @@
 				"$(BUILT_PRODUCTS_DIR)/installXcode",
 			);
 			outputPaths = (
-				"$(DATDIR)/installXcode",
+				"$(DSTROOT)/$(DATDIR)/darwinbuild/installXcode",
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
-			shellScript = "/bin/cp $BUILT_PRODUCTS_DIR/installXcode $DATDIR/installXcode";
+			shellScript = "mkdir -p $DSTROOT/$DATDIR/darwinbuild\n/bin/cp $BUILT_PRODUCTS_DIR/installXcode $DSTROOT/$DATDIR/darwinbuild/installXcode";
 			showEnvVarsInLog = 0;
 		};
 		1F71A5022030F88300020E2F /* ShellScript */ = {
@@ -2075,11 +2075,11 @@
 				"$(BUILT_PRODUCTS_DIR)/installXcode32",
 			);
 			outputPaths = (
-				"$(DATDIR)/installXcode32",
+				"$(DSTROOT)/$(DATDIR)/installXcode32",
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
-			shellScript = "mkdir -p $DATDIR\n/bin/cp $BUILT_PRODUCTS_DIR/installXcode32 $DATDIR/installXcode32";
+			shellScript = "mkdir -p $DSTROOT/$DATDIR/darwinbuild\n/bin/cp $BUILT_PRODUCTS_DIR/installXcode32 $DSTROOT/$DATDIR/darwinbuild/installXcode32";
 			showEnvVarsInLog = 0;
 		};
 		7227AB8F1098A89700BE33D7 /* Run Script */ = {


### PR DESCRIPTION
When I committed 4a2368a26a97, I neglected to apply the same fix to the other shell script-based tools in darwinbuild, including darwinmaster and the helper scripts under /usr/local/share. I did not catch this error before. All scripts should now be installed as required.