### PR TITLE
Add support for xcbuild, and re-enable the chroot by default

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "xcbuild"]
+	path = xcbuild
+	url = git@github.com:Andromeda-OS/xcbuild

--- a/darwinbuild.xcodeproj/project.pbxproj
+++ b/darwinbuild.xcodeproj/project.pbxproj
@@ -2122,7 +2122,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "which -s cmake || {\n    echo CMake is required. Try \\`brew install cmake\\` 1>&2\n    exit 1\n}\n\nwhich -s ninja || {\n    echo ninja is required. Try \\`brew install ninja\\` 1>&2\n    exit 1\n}\n\nset -e\ncd \"${SRCROOT}/xcbuild\"\nmkdir -p $DERIVED_FILE_DIR\nmake all &> $DERIVED_FILE_DIR/xcbuild.log";
+			shellScript = "which -s cmake || {\n    echo CMake is required. Try \\`brew install cmake\\` 1>&2\n    exit 1\n}\n\nwhich -s ninja || {\n    echo ninja is required. Try \\`brew install ninja\\` 1>&2\n    exit 1\n}\n\nif [ ! -f \"${SRCROOT}/xcbuild/Makefile\" ]; then\n    echo xcbuild submodule not checked out, not building\n    exit 0\nfi\n\nif [ ! -f \"${SRCROOT}/xcbuild/ThirdParty/googletest/CMakeLists.txt\" -o ! -f \"${SRCROOT}/xcbuild/ThirdParty/linenoise/Makefile\" ]; then\n    echo Submodules of xcbuild submodule not checked out, build will not succeed 1>&2\n    echo Try \\`git submodule update --init --recursive\\` 1>&2\n    exit 1\nfi\n\nset -e\ncd \"${SRCROOT}/xcbuild\"\nmkdir -p $DERIVED_FILE_DIR\nmake all &> $DERIVED_FILE_DIR/xcbuild.log";
 			showEnvVarsInLog = 0;
 		};
 		1FAB24D92043A66800329636 /* Install */ = {

--- a/darwinbuild.xcodeproj/project.pbxproj
+++ b/darwinbuild.xcodeproj/project.pbxproj
@@ -7,6 +7,18 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
+		1FAB24D32043A61B00329636 /* xcbuild */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 1FAB24D72043A61B00329636 /* Build configuration list for PBXAggregateTarget "xcbuild" */;
+			buildPhases = (
+				1FAB24D82043A61F00329636 /* Build */,
+				1FAB24D92043A66800329636 /* Install */,
+			);
+			dependencies = (
+			);
+			name = xcbuild;
+			productName = xcbuild;
+		};
 		7227AB3D1098977C00BE33D7 /* tcl_plugins */ = {
 			isa = PBXAggregateTarget;
 			buildConfigurationList = 7227AB4A109897E500BE33D7 /* Build configuration list for PBXAggregateTarget "tcl_plugins" */;
@@ -78,6 +90,7 @@
 			buildPhases = (
 			);
 			dependencies = (
+				1FAB24DB2043A6A900329636 /* PBXTargetDependency */,
 				72C86C5F1096617500C66E90 /* PBXTargetDependency */,
 				72C86C611096617500C66E90 /* PBXTargetDependency */,
 				725740971097B03D008AD4D7 /* PBXTargetDependency */,
@@ -166,6 +179,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		1FAB24DA2043A6A900329636 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 726DD14910965C5700D5AEAB /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1FAB24D32043A61B00329636;
+			remoteInfo = xcbuild;
+		};
 		3963011E1EAB4E01006081C7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 726DD14910965C5700D5AEAB /* Project object */;
@@ -1925,6 +1945,13 @@
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 0930;
 				ORGANIZATIONNAME = "The DarwinBuild Project";
+				TargetAttributes = {
+					1FAB24D32043A61B00329636 = {
+						CreatedOnToolsVersion = 9.3;
+						DevelopmentTeam = 3P242C9ES5;
+						ProvisioningStyle = Automatic;
+					};
+				};
 			};
 			buildConfigurationList = 726DD14C10965C5700D5AEAB /* Build configuration list for PBXProject "darwinbuild" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -1981,6 +2008,7 @@
 				7227AC271098DBDF00BE33D7 /* installXcode32 */,
 				720BE2EA120C90A700B3C4A5 /* digest */,
 				3963011C1EAB4E01006081C7 /* patch_sites */,
+				1FAB24D32043A61B00329636 /* xcbuild */,
 			);
 		};
 /* End PBXProject section */
@@ -2080,6 +2108,36 @@
 			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
 			shellScript = "mkdir -p $DSTROOT/$DATDIR/darwinbuild\n/bin/cp $BUILT_PRODUCTS_DIR/installXcode32 $DSTROOT/$DATDIR/darwinbuild/installXcode32";
+			showEnvVarsInLog = 0;
+		};
+		1FAB24D82043A61F00329636 /* Build */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = Build;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "which -s cmake || {\n    echo CMake is required. Try \\`brew install cmake\\` 1>&2\n    exit 1\n}\n\nwhich -s ninja || {\n    echo ninja is required. Try \\`brew install ninja\\` 1>&2\n    exit 1\n}\n\nset -e\ncd \"${SRCROOT}/xcbuild\"\nmkdir -p $DERIVED_FILE_DIR\nmake all &> $DERIVED_FILE_DIR/xcbuild.log";
+			showEnvVarsInLog = 0;
+		};
+		1FAB24D92043A66800329636 /* Install */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 8;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = Install;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+			shellPath = /bin/sh;
+			shellScript = "cp -f \"${SRCROOT}/xcbuild/build/xcbuild\" $DSTROOT/$DATDIR/darwinbuild/xcbuild\n";
 			showEnvVarsInLog = 0;
 		};
 		7227AB8F1098A89700BE33D7 /* Run Script */ = {
@@ -2524,6 +2582,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		1FAB24DB2043A6A900329636 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1FAB24D32043A61B00329636 /* xcbuild */;
+			targetProxy = 1FAB24DA2043A6A900329636 /* PBXContainerItemProxy */;
+		};
 		3963011D1EAB4E01006081C7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 7257499F1097697300B13BC3 /* darwinxref */;
@@ -2842,6 +2905,33 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		1FAB24D42043A61B00329636 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 3P242C9ES5;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		1FAB24D52043A61B00329636 /* Public */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 3P242C9ES5;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Public;
+		};
+		1FAB24D62043A61B00329636 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 3P242C9ES5;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		396301241EAB4E01006081C7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 72574B3E10979D6000B13BC3 /* c_plugins.xcconfig */;
@@ -4097,6 +4187,16 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		1FAB24D72043A61B00329636 /* Build configuration list for PBXAggregateTarget "xcbuild" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1FAB24D42043A61B00329636 /* Debug */,
+				1FAB24D52043A61B00329636 /* Public */,
+				1FAB24D62043A61B00329636 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Public;
+		};
 		396301231EAB4E01006081C7 /* Build configuration list for PBXNativeTarget "patch_sites" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/darwinbuild.xcodeproj/project.pbxproj
+++ b/darwinbuild.xcodeproj/project.pbxproj
@@ -2137,7 +2137,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
-			shellScript = "cp -f \"${SRCROOT}/xcbuild/build/xcbuild\" $DSTROOT/$DATDIR/darwinbuild/xcbuild\n";
+			shellScript = "cp -f \"${SRCROOT}/xcbuild/build/xcbuild\" $DSTROOT/$DATDIR/darwinbuild/xcbuild.disabled\n";
 			showEnvVarsInLog = 0;
 		};
 		7227AB8F1098A89700BE33D7 /* Run Script */ = {

--- a/darwinbuild.xcodeproj/project.pbxproj
+++ b/darwinbuild.xcodeproj/project.pbxproj
@@ -2137,7 +2137,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
-			shellScript = "cp -f \"${SRCROOT}/xcbuild/build/xcbuild\" $DSTROOT/$DATDIR/darwinbuild/xcbuild.disabled\n";
+			shellScript = "if [ -f \"${SRCROOT}/xcbuild/build/xcbuild\" ]; then\n    cp -f \"${SRCROOT}/xcbuild/build/xcbuild\" $DSTROOT/$DATDIR/darwinbuild/xcbuild.disabled\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		7227AB8F1098A89700BE33D7 /* Run Script */ = {

--- a/darwinbuild/darwinbuild.in
+++ b/darwinbuild/darwinbuild.in
@@ -98,7 +98,7 @@ target=""
 configuration=""
 version=""
 
-USE_CHROOT="NO"
+USE_CHROOT="YES"
 INSTALL_XCODE="NO"
 
 ###
@@ -192,7 +192,7 @@ function PrintUsage() {
 	usage: $(basename $0) [action] [options] <project> [<version>]
 	actions: [-headers] [-fetch] [-source] [-load] [-loadonly]
 	options: [-build=X] [-target=X] [-configuration=X]
-	         [-logdeps] [-chroot] [-nopatch] [-noload]
+	         [-logdeps] [-nochroot] [-nopatch] [-noload]
 	         [-depsbuild=X [-depsbuild=Y]] [-nosource]
 
 EOF
@@ -263,8 +263,8 @@ fi
 ###   -logdeps  Do magic to log the build-time dependencies
 ###   -nopatch  Don't patch sources before building.
 ###   -noload   Don't load dependencies into the chroot.
-###		 Has no effect unless -chroot is specified.
-###   -chroot   chroot into the BuildRoot when building
+###		 Has no effect if -nochroot is specified.
+###   -nochroot Do not chroot into the BuildRoot when building
 ###   -target=X The makefile or xcode target to build
 ###   -configuration=X Specify the build configuration to use
 ###   -build=X  Specify the darwin build number to buld, e.g. 8B15
@@ -300,8 +300,9 @@ for ARG in "$@"; do
 			build="${ARG/*=/}"
 		elif [ "${ARG/=*/}" == "-depsbuild" ]; then
 			depsbuild="${depsbuild} ${ARG/*=/}"
-		elif [ "$ARG" == "-chroot" ]; then
-			export USE_CHROOT="YES"
+		elif [ "$ARG" == "-nochroot" ]; then
+			export INSTALL_XCODE="NO"
+			export USE_CHROOT="NO"
 		elif [ "$ARG" == "-nopatch" ]; then
 			nopatch="YES"
 		elif [ "$ARG" == "-load" ]; then

--- a/darwinbuild/installXcode_Modern
+++ b/darwinbuild/installXcode_Modern
@@ -64,7 +64,7 @@ mkdir -p $BUILDROOT/$(getconf DARWIN_USER_DIR)
 mkdir -p $BUILDROOT/$(getconf DARWIN_USER_TEMP_DIR)
 mkdir -p $BUILDROOT/$(getconf DARWIN_USER_CACHE_DIR)
 
-if [ "$HOST_DARWIN_VERSION" == "10.13" ]; then
+if [[ "$HOST_DARWIN_VERSION" =~ ^10.13 ]]; then
     rm $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk
     mv $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk
 
@@ -84,7 +84,7 @@ if [ "$HOST_DARWIN_VERSION" == "10.13" ]; then
 EOF
 
     codesign -s - -f --entitlements $BUILDROOT/private/tmp/empty.entitlements $BUILDROOT/Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild
-elif [ "$HOST_DARWIN_VERSION" == "10.12" ]; then
+elif [[ "$HOST_DARWIN_VERSION" =~ ^10.12 ]]; then
     rm $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
     mv $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
 fi

--- a/darwinbuild/installXcode_Modern
+++ b/darwinbuild/installXcode_Modern
@@ -71,10 +71,15 @@ if [[ "$HOST_DARWIN_VERSION" =~ ^10.13 ]]; then
     mkdir -p $BUILDROOT/private/var/db
     ln -s /Applications/Xcode.app/Contents/Developer $BUILDROOT/private/var/db/xcode_select_link
 
-    # High Sierra does not allow processes with entitlements to run inside a chroot.
-    # Therefore, I must strip the entitlements and re-sign xcodebuild.
-    # Hopefully, this won't break anything.
-    cat <<EOF > $BUILDROOT/private/tmp/empty.entitlements
+    if [ -x /usr/local/share/darwinbuild/xcbuild ]; then
+        # If it is available, overwrite Apple's xcodebuild with xcbuild.
+        # This helps avoid the issue described in the 'else' block below.
+        cp -f /usr/local/share/darwinbuild/xcbuild $BUILDROOT/Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild
+    else
+        # High Sierra does not allow processes with entitlements to run inside a chroot.
+        # Therefore, I must strip the entitlements and re-sign xcodebuild.
+        # Hopefully, this won't break anything.
+        cat <<EOF > $BUILDROOT/private/tmp/empty.entitlements
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -83,7 +88,8 @@ if [[ "$HOST_DARWIN_VERSION" =~ ^10.13 ]]; then
 </plist>
 EOF
 
-    codesign -s - -f --entitlements $BUILDROOT/private/tmp/empty.entitlements $BUILDROOT/Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild
+        codesign -s - -f --entitlements $BUILDROOT/private/tmp/empty.entitlements $BUILDROOT/Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild
+    fi
 elif [[ "$HOST_DARWIN_VERSION" =~ ^10.12 ]]; then
     rm $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
     mv $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk $BUILDROOT/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk


### PR DESCRIPTION
After some soul-searching, I have determined that the workaround I am using to make xcodebuild work in the chroot isn't actually that bad for the short-term (and that the contortions I have to put Xcode through to make it work with higher-level components sans chroot are far worse). Long-term, I am working on bringing up xcbuild to where it is a usable replacement for xcodebuild that doesn't suffer from this issue.
