### PR TITLE
Support passing multiple projects to darwinbuild-recursive

### DIFF
--- a/darwinbuild.xcodeproj/project.pbxproj
+++ b/darwinbuild.xcodeproj/project.pbxproj
@@ -1873,7 +1873,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1100;
-				LastUpgradeCheck = 1100;
+				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = "The DarwinBuild Project";
 				TargetAttributes = {
 					1FA2A9E622E62BF600F53888 = {

--- a/darwinbuild.xcodeproj/xcshareddata/xcschemes/darwinbuild-codesign.xcscheme
+++ b/darwinbuild.xcodeproj/xcshareddata/xcschemes/darwinbuild-codesign.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/darwinbuild.xcodeproj/xcshareddata/xcschemes/darwinbuild-recursive.xcscheme
+++ b/darwinbuild.xcodeproj/xcshareddata/xcschemes/darwinbuild-recursive.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/darwinbuild.xcodeproj/xcshareddata/xcschemes/world.xcscheme
+++ b/darwinbuild.xcodeproj/xcshareddata/xcschemes/world.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/darwinbuild/darwinbuild.in
+++ b/darwinbuild/darwinbuild.in
@@ -242,7 +242,7 @@ fi
 ###   -source    Extract, patch, and stage source
 ###   -load      Populate the BuildRoot with one project
 ###   -loadonly  Only load dependencies into the build root, but don't build.
-###   -recursive Build given project and all required dependencies
+###   -recursive Build given project(s) and all required dependencies
 ###   -group     Build all projects in the given darwinxref group,
 ###              as with darwinbuild -recursive
 ###
@@ -267,6 +267,11 @@ if [ "$DARWINBUILD_BUILD" != "" ]; then
 	build="$DARWINBUILD_BUILD"
 fi
 
+if [ "$1" == "-recursive" ]; then
+	shift
+	exec $DATADIR/darwinbuild-recursive -p "$@"
+fi
+
 for ARG in "$@"; do
 	if [ "$projnam" == "" ]; then
 		if [ "$ARG" == "-headers" ]; then
@@ -280,7 +285,8 @@ for ARG in "$@"; do
 		elif [ "$ARG" == "-source" ]; then
 			action="source"
 		elif [ "$ARG" = "-recursive" ]; then
-			action="recursive"
+			echo "Error: -recursive only supported as first argument to darwinbuild" 1>&2
+			exit 1
 		elif [ "$ARG" = "-group" ]; then
 			action="group"
 		elif [ "${ARG/=*/}" == "-target" ]; then
@@ -358,7 +364,7 @@ fi
 
 ###
 ### If we are doing a -load, install the root and exit.
-### Also handle -recursive and -group here.
+### Also handle -group here.
 ###
 if [ "$action" == "load" ]; then
 	InstallRoot "$BuildRoot" "$projnam" "$depsbuild"
@@ -366,8 +372,6 @@ if [ "$action" == "load" ]; then
 elif [ "$action" == "loadhdrs" ]; then
 	InstallHeader "$BuildRoot" "$projnam" "$depsbuild"
 	exit 0
-elif [ "$action" == "recursive" ]; then
-	exec $DATADIR/darwinbuild-recursive -p "$projnam"
 elif [ "$action" == "group" ]; then
 	exec $DATADIR/darwinbuild-recursive -g "$projnam"
 fi

--- a/swift/darwinbuild-recursive/main.swift
+++ b/swift/darwinbuild-recursive/main.swift
@@ -127,7 +127,9 @@ func main() {
 			}
 		}
 	} else if CommandLine.arguments[1] == "-p" {
-		context.buildProject(projectName: CommandLine.arguments[2])
+		for projectName in CommandLine.arguments[2...] {
+			context.buildProject(projectName: projectName)
+		}
 	} else {
 		print("ERROR: First argument must be either -g or -p", to: &standardError)
 		exit(1)


### PR DESCRIPTION
Once this PR is merged, you can do `sudo darwinbuild -recursive xnu libpthread libdispatch` and it will build those three projects (or however many are specified on the command line) and their dependencies, while ensuring that each dependent project is built only once.