### PR TITLE
Add ~n suffixes before the filename extension

### DIFF
--- a/darwinbuild/darwinbuild.in
+++ b/darwinbuild/darwinbuild.in
@@ -620,7 +620,7 @@ fi
 version="${project/$projnam-/}"
 build_version=$(($(GetBuildVersion $DARWIN_BUILDROOT/{Logs,Symbols,Headers,Roots}/$projnam/$project.*) + 1))
 
-LOG="$DARWIN_BUILDROOT/Logs/$projnam/$project.log~$build_version"
+LOG="$DARWIN_BUILDROOT/Logs/$projnam/$project~${build_version}.log"
 TRACELOG="$BuildRoot/private/var/tmp/$projnam/$project.trace~$build_version"
 mkdir -p "$DARWIN_BUILDROOT/Logs/$projnam"
 
@@ -872,7 +872,7 @@ if [ "$EXIT_STATUS" == "0" ]; then
 			sort -u | \
 			"$DARWINXREF" loadDeps "$projnam" "$prefix"
 			"$DARWINXREF" resolveDeps -commit "$projnam"
-			cp "$TRACELOG" $DARWIN_BUILDROOT/Logs/$projnam/$project.trace~$build_version
+			cp "$TRACELOG" $DARWIN_BUILDROOT/Logs/$projnam/$project~${build_version}.deps.log
 		fi
 	fi
 fi


### PR DESCRIPTION
This ensures that build log files will always in `log`, which enables the Finder and other applications to automatically
recognize them as text files. Previously, the build number was appended at the end of the extension, resulting in filenames like `AvailabilityVersions-45.5.log~5`. The new filename would be `AvailabilityVersions-45.5~5.log`.

I also made the same change to the .trace files emitted when you pass the `-logdeps` flag to darwinbuild, which now always end in `.deps.log`.